### PR TITLE
Ease acceptable error range to be wider

### DIFF
--- a/pageinfo.py
+++ b/pageinfo.py
@@ -175,7 +175,7 @@ def guess_pages(actual_width, actual_height, entire_width, entire_height):
         スクロールバー領域の高さからドロップ枠が何ページあるか推定する
     """
     delta = abs(entire_width - actual_width)
-    if delta > 9:
+    if delta > 15:
         # 比較しようとしている領域が異なる可能性が高い
         raise CannotGuessError(
             f'幅の誤差が大きすぎます: delta = {delta}, '
@@ -195,7 +195,7 @@ def guess_pagenum(actual_x, actual_y, entire_x, entire_y, entire_height):
     """
         スクロールバー領域の y 座標の位置からドロップ画像のページ数を推定する
     """
-    if abs(actual_x - entire_x) > 9:
+    if abs(actual_x - entire_x) > 12:
         # 比較しようとしている領域が異なる可能性が高い
         raise CannotGuessError(f'x 座標の誤差が大きすぎます: entire_x = {entire_x}, actual_x = {actual_x}')
 
@@ -221,7 +221,7 @@ def guess_lines(actual_width, actual_height, entire_width, entire_height):
         スクロールバーを用いる関係上、原理的に 2 行以下は推定不可
     """
     delta = abs(entire_width - actual_width)
-    if delta > 9:
+    if delta > 15:
         # 比較しようとしている領域が異なる可能性が高い
         raise CannotGuessError(
             f'幅の誤差が大きすぎます: delta = {delta}, '


### PR DESCRIPTION
In order to recognize various screenshots including NA version, we have to ease acceptable error range about a gap between width of a scrollbar and width of a scrollable area.

多様なパターンのスクリーンショット（NA版を含む）を認識するため、スクロールバーとスクロール可能領域の誤差許容幅を現在よりも広げる。この修正は既存のJP画像に悪影響はないと判断。